### PR TITLE
feat: Add pre-flight validation before pipeline ingestion

### DIFF
--- a/src/graphrag_kg_pipeline/__init__.py
+++ b/src/graphrag_kg_pipeline/__init__.py
@@ -134,6 +134,7 @@ from .postprocessing import (
     normalize_entity_name,
     normalize_industry,
 )
+from .preflight import PreflightError
 
 # =============================================================================
 # SCRAPER (always available)
@@ -239,5 +240,6 @@ __all__ = [
     "FetchError",
     "Neo4jConfigError",
     "PlaywrightNotAvailableError",
+    "PreflightError",
     "ScraperError",
 ]

--- a/src/graphrag_kg_pipeline/cli.py
+++ b/src/graphrag_kg_pipeline/cli.py
@@ -29,6 +29,7 @@ from .exceptions import (
     Neo4jConfigError,
     PlaywrightNotAvailableError,
 )
+from .preflight import PreflightError
 from .scraper import run_scraper
 
 console = Console()
@@ -312,11 +313,13 @@ def _run_scrape_command(args: argparse.Namespace) -> None:
         console.print("[yellow]Dry run mode - no changes will be made[/]")
         console.print()
         console.print("Estimated processing:")
-        console.print("  - ~103 articles")
-        console.print("  - ~15 chapters")
-        console.print("  - ~100 glossary terms")
-        console.print("  - Embedding cost: ~$0.50-1.00 (text-embedding-3-small)")
-        console.print("  - LLM extraction cost: ~$5-10 (gpt-4o)")
+        console.print("  - ~103 articles, ~15 chapters, ~100 glossary terms")
+        console.print("  - Embedding cost: ~$0.10 (Voyage AI) or ~$0.50 (OpenAI)")
+        console.print("  - LLM extraction cost: ~$5-10 (gpt-4o, 2 gleaning passes)")
+        console.print("  - Entity summarization: ~$1-2 (gpt-4o)")
+        console.print("  - Community summaries: ~$0.10 (gpt-4o-mini)")
+        console.print("  - Estimated total: ~$7-13")
+        console.print("  - Estimated time: ~1.5 hours")
         return
 
     try:
@@ -341,6 +344,9 @@ def _run_scrape_command(args: argparse.Namespace) -> None:
     except Neo4jConfigError:
         console.print("\n[red]Error: Neo4j configuration missing[/]")
         console.print("Set: [cyan]NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD[/]")
+        raise SystemExit(1) from None
+    except PreflightError:
+        # Error details already printed by _run_preflight()
         raise SystemExit(1) from None
     except KeyboardInterrupt:
         console.print("\n[yellow]Pipeline interrupted by user[/]")

--- a/src/graphrag_kg_pipeline/preflight.py
+++ b/src/graphrag_kg_pipeline/preflight.py
@@ -1,0 +1,294 @@
+"""Pre-flight validation for the GraphRAG ingestion pipeline.
+
+Runs automated checks before starting a potentially long ingestion run
+to catch configuration and connectivity issues early. All checks are
+fail-fast: the first critical failure aborts with a clear error message.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from neo4j import AsyncDriver
+
+logger = structlog.get_logger(__name__)
+
+
+class PreflightError(Exception):
+    """Pre-flight validation failed.
+
+    Raised when a critical check fails during pre-flight validation.
+    Contains a user-friendly message describing the issue and how to fix it.
+    """
+
+
+@dataclass
+class PreflightResult:
+    """Result of all pre-flight checks.
+
+    Attributes:
+        neo4j_connected: Whether Neo4j is reachable.
+        apoc_version: APOC Core version string, or empty if unavailable.
+        node_count: Number of existing nodes in the database.
+        vector_index_dimensions: Dimensions of existing vector index, or None if no index.
+        voyage_api_valid: Whether the Voyage API key produced a valid embedding.
+        using_voyage: Whether Voyage AI will be used for embeddings.
+    """
+
+    neo4j_connected: bool = False
+    apoc_version: str = ""
+    node_count: int = 0
+    vector_index_dimensions: int | None = None
+    voyage_api_valid: bool = False
+    using_voyage: bool = False
+
+
+async def run_preflight_checks(
+    driver: AsyncDriver,
+    database: str = "neo4j",
+    expected_dimensions: int = 1536,
+    voyage_api_key: str = "",
+) -> PreflightResult:
+    """Run all pre-flight validation checks.
+
+    Checks are run sequentially — the first critical failure raises PreflightError.
+    Non-critical issues (e.g., existing data) are logged as warnings.
+
+    Args:
+        driver: Async Neo4j driver.
+        database: Neo4j database name.
+        expected_dimensions: Expected embedding vector dimensions.
+        voyage_api_key: Voyage AI API key (empty string to skip check).
+
+    Returns:
+        PreflightResult with check outcomes.
+
+    Raises:
+        PreflightError: If a critical check fails.
+    """
+    result = PreflightResult(using_voyage=bool(voyage_api_key))
+
+    # 1. Neo4j connectivity
+    await _check_neo4j_connectivity(driver, database, result)
+
+    # 2. APOC availability
+    await _check_apoc(driver, database, result)
+
+    # 3. Existing data warning
+    await _check_existing_data(driver, database, result)
+
+    # 4. Vector index dimensions
+    await _check_vector_index(driver, database, expected_dimensions, result)
+
+    # 5. Voyage API key validity
+    if voyage_api_key:
+        await _check_voyage_api(voyage_api_key, expected_dimensions, result)
+
+    logger.info(
+        "Pre-flight checks passed",
+        neo4j=result.neo4j_connected,
+        apoc=result.apoc_version,
+        node_count=result.node_count,
+        vector_index_dims=result.vector_index_dimensions,
+        using_voyage=result.using_voyage,
+        voyage_valid=result.voyage_api_valid,
+    )
+
+    return result
+
+
+async def _check_neo4j_connectivity(
+    driver: AsyncDriver,
+    database: str,
+    result: PreflightResult,
+) -> None:
+    """Verify the Neo4j database is reachable.
+
+    Args:
+        driver: Async Neo4j driver.
+        database: Database name.
+        result: PreflightResult to update.
+
+    Raises:
+        PreflightError: If the database is unreachable.
+    """
+    try:
+        async with driver.session(database=database) as session:
+            records = await session.run("RETURN 1 AS ping")
+            record = await records.single()
+            if record and record["ping"] == 1:
+                result.neo4j_connected = True
+                logger.info("Neo4j connectivity check passed")
+                return
+    except Exception as e:
+        msg = (
+            f"Cannot connect to Neo4j: {e}\n"
+            "Check NEO4J_URI, NEO4J_USERNAME, and NEO4J_PASSWORD in your .env file."
+        )
+        raise PreflightError(msg) from e
+
+    msg = "Neo4j returned unexpected response to ping query."
+    raise PreflightError(msg)
+
+
+async def _check_apoc(
+    driver: AsyncDriver,
+    database: str,
+    result: PreflightResult,
+) -> None:
+    """Verify APOC Core is installed.
+
+    APOC is required by EntityCleanupNormalizer (apoc.merge.relationship)
+    and neo4j_graphrag (apoc.create.addLabels).
+
+    Args:
+        driver: Async Neo4j driver.
+        database: Database name.
+        result: PreflightResult to update.
+
+    Raises:
+        PreflightError: If APOC is not available.
+    """
+    try:
+        async with driver.session(database=database) as session:
+            records = await session.run("RETURN apoc.version() AS version")
+            record = await records.single()
+            if record:
+                result.apoc_version = record["version"]
+                logger.info("APOC check passed", version=result.apoc_version)
+                return
+    except Exception as e:
+        msg = (
+            f"APOC Core is not available: {e}\n"
+            "APOC is required by the pipeline (apoc.create.addLabels, "
+            "apoc.merge.relationship). On Aura Professional, APOC Core "
+            "is pre-installed. For self-hosted, install the APOC plugin."
+        )
+        raise PreflightError(msg) from e
+
+    msg = "APOC version query returned no result."
+    raise PreflightError(msg)
+
+
+async def _check_existing_data(
+    driver: AsyncDriver,
+    database: str,
+    result: PreflightResult,
+) -> None:
+    """Check for existing data and warn if the graph is not empty.
+
+    This is a non-critical warning — the pipeline can still run, but
+    re-ingestion without clearing first may create duplicates.
+
+    Args:
+        driver: Async Neo4j driver.
+        database: Database name.
+        result: PreflightResult to update.
+    """
+    async with driver.session(database=database) as session:
+        records = await session.run("MATCH (n) RETURN count(n) AS count")
+        record = await records.single()
+        if record:
+            result.node_count = record["count"]
+
+    if result.node_count > 0:
+        logger.warning(
+            "Database contains existing data — re-ingestion may create duplicates. "
+            "Clear with: MATCH (n) DETACH DELETE n",
+            node_count=result.node_count,
+        )
+
+
+async def _check_vector_index(
+    driver: AsyncDriver,
+    database: str,
+    expected_dimensions: int,
+    result: PreflightResult,
+) -> None:
+    """Check existing vector index dimensions for consistency.
+
+    If a vector index exists with different dimensions than the configured
+    embedder, the pipeline will fail silently or produce unusable embeddings.
+
+    Args:
+        driver: Async Neo4j driver.
+        database: Database name.
+        expected_dimensions: Expected embedding dimensions from config.
+        result: PreflightResult to update.
+
+    Raises:
+        PreflightError: If an existing index has mismatched dimensions.
+    """
+    async with driver.session(database=database) as session:
+        records = await session.run("SHOW INDEXES")
+        async for record in records:
+            record_dict = dict(record)
+            if record_dict.get("type") == "VECTOR":
+                index_config = record_dict.get("indexConfig", {})
+                dims = index_config.get("vector.dimensions")
+                if dims is not None:
+                    result.vector_index_dimensions = int(dims)
+                    if result.vector_index_dimensions != expected_dimensions:
+                        index_name = record_dict.get("name", "unknown")
+                        msg = (
+                            f"Vector index '{index_name}' has {result.vector_index_dimensions} "
+                            f"dimensions but embedder is configured for {expected_dimensions}. "
+                            f"Drop the index with: DROP INDEX {index_name}"
+                        )
+                        raise PreflightError(msg)
+                    logger.info(
+                        "Vector index dimensions match",
+                        dimensions=result.vector_index_dimensions,
+                    )
+                    return
+
+    logger.info("No existing vector index found — one will be created during ingestion")
+
+
+async def _check_voyage_api(
+    voyage_api_key: str,
+    expected_dimensions: int,
+    result: PreflightResult,
+) -> None:
+    """Validate the Voyage API key with a test embedding call.
+
+    Args:
+        voyage_api_key: Voyage AI API key.
+        expected_dimensions: Expected output dimensions.
+        result: PreflightResult to update.
+
+    Raises:
+        PreflightError: If the API key is invalid or the call fails.
+    """
+    try:
+        import voyageai  # noqa: PLC0415
+
+        client = voyageai.Client(api_key=voyage_api_key)
+        test_result = client.embed(
+            ["preflight check"],
+            model="voyage-4",
+            input_type="document",
+            output_dimension=expected_dimensions,
+        )
+    except Exception as e:
+        msg = (
+            f"Voyage AI API check failed: {e}\n"
+            "Verify VOYAGE_API_KEY in your .env file, or remove it to use OpenAI embeddings."
+        )
+        raise PreflightError(msg) from e
+
+    if test_result.embeddings and len(test_result.embeddings[0]) == expected_dimensions:
+        result.voyage_api_valid = True
+        logger.info(
+            "Voyage AI API check passed",
+            dimensions=len(test_result.embeddings[0]),
+        )
+        return
+
+    actual_dims = len(test_result.embeddings[0]) if test_result.embeddings else 0
+    msg = f"Voyage AI returned {actual_dims} dimensions but expected {expected_dimensions}."
+    raise PreflightError(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -413,4 +413,6 @@ def mock_env_vars(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
     }
     for key, value in env_vars.items():
         monkeypatch.setenv(key, value)
+    # Set optional keys to empty so load_dotenv() won't refill from .env
+    monkeypatch.setenv("VOYAGE_API_KEY", "")
     return env_vars

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,330 @@
+"""Tests for pre-flight validation checks.
+
+Verifies each check produces the correct result on success and raises
+PreflightError with a helpful message on failure.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphrag_kg_pipeline.preflight import (
+    PreflightError,
+    PreflightResult,
+    _check_apoc,
+    _check_existing_data,
+    _check_neo4j_connectivity,
+    _check_vector_index,
+    _check_voyage_api,
+    run_preflight_checks,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_record(data: dict) -> MagicMock:
+    """Create a mock Neo4j record that supports dict-style access and dict() conversion."""
+    record = MagicMock()
+    record.__getitem__ = lambda _self, k: data[k]
+    record.keys = MagicMock(return_value=data.keys())
+    return record
+
+
+class _AsyncRecordIterator:
+    """Async iterator over mock Neo4j records."""
+
+    def __init__(self, records: list[MagicMock]) -> None:
+        self._records = iter(records)
+
+    def __aiter__(self) -> _AsyncRecordIterator:
+        return self
+
+    async def __anext__(self) -> MagicMock:
+        try:
+            return next(self._records)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+def _make_async_result(records: list[dict]) -> AsyncMock:
+    """Create a mock Neo4j result with async iteration and single() support."""
+    mock_records = [_make_record(r) for r in records]
+    mock_result = MagicMock()
+    mock_result.single = AsyncMock(return_value=mock_records[0] if mock_records else None)
+    mock_result.__aiter__ = lambda _self: _AsyncRecordIterator(mock_records)
+    return mock_result
+
+
+def _mock_driver(records: list[dict] | None = None) -> AsyncMock:
+    """Create a mock async Neo4j driver that returns given records."""
+    driver = AsyncMock()
+    session = AsyncMock()
+
+    if records is not None:
+        session.run = AsyncMock(return_value=_make_async_result(records))
+    else:
+        session.run = AsyncMock(side_effect=Exception("Connection refused"))
+
+    driver.session = MagicMock(return_value=session)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+
+    return driver
+
+
+# ---------------------------------------------------------------------------
+# Neo4j Connectivity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_neo4j_connectivity_success() -> None:
+    """Passes when Neo4j returns expected ping response."""
+    driver = _mock_driver([{"ping": 1}])
+    result = PreflightResult()
+    await _check_neo4j_connectivity(driver, "neo4j", result)
+    assert result.neo4j_connected is True
+
+
+@pytest.mark.asyncio
+async def test_neo4j_connectivity_failure() -> None:
+    """Raises PreflightError when Neo4j is unreachable."""
+    driver = _mock_driver(None)
+    result = PreflightResult()
+    with pytest.raises(PreflightError, match="Cannot connect to Neo4j"):
+        await _check_neo4j_connectivity(driver, "neo4j", result)
+
+
+# ---------------------------------------------------------------------------
+# APOC Check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apoc_check_success() -> None:
+    """Passes when APOC returns a version string."""
+    driver = _mock_driver([{"version": "5.25.0"}])
+    result = PreflightResult()
+    await _check_apoc(driver, "neo4j", result)
+    assert result.apoc_version == "5.25.0"
+
+
+@pytest.mark.asyncio
+async def test_apoc_check_failure() -> None:
+    """Raises PreflightError when APOC is not installed."""
+    driver = _mock_driver(None)
+    result = PreflightResult()
+    with pytest.raises(PreflightError, match="APOC Core is not available"):
+        await _check_apoc(driver, "neo4j", result)
+
+
+# ---------------------------------------------------------------------------
+# Existing Data Warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_existing_data_empty() -> None:
+    """Reports zero nodes for empty graph."""
+    driver = _mock_driver([{"count": 0}])
+    result = PreflightResult()
+    await _check_existing_data(driver, "neo4j", result)
+    assert result.node_count == 0
+
+
+@pytest.mark.asyncio
+async def test_existing_data_nonempty() -> None:
+    """Reports node count for non-empty graph (warning only, no error)."""
+    driver = _mock_driver([{"count": 6400}])
+    result = PreflightResult()
+    await _check_existing_data(driver, "neo4j", result)
+    assert result.node_count == 6400
+
+
+# ---------------------------------------------------------------------------
+# Vector Index Check
+# ---------------------------------------------------------------------------
+
+
+def _mock_driver_with_index(dims: int) -> AsyncMock:
+    """Create a mock driver that returns a VECTOR index with given dimensions."""
+    driver = AsyncMock()
+    session = AsyncMock()
+
+    index_record = {
+        "type": "VECTOR",
+        "name": "chunk_embeddings",
+        "indexConfig": {"vector.dimensions": dims},
+    }
+    session.run = AsyncMock(return_value=_make_async_result([index_record]))
+
+    driver.session = MagicMock(return_value=session)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+
+    return driver
+
+
+def _mock_driver_no_indexes() -> AsyncMock:
+    """Create a mock driver with no indexes."""
+    driver = AsyncMock()
+    session = AsyncMock()
+
+    mock_result = MagicMock()
+    mock_result.__aiter__ = lambda _self: _AsyncRecordIterator([])
+    session.run = AsyncMock(return_value=mock_result)
+
+    driver.session = MagicMock(return_value=session)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+
+    return driver
+
+
+@pytest.mark.asyncio
+async def test_vector_index_matching_dimensions() -> None:
+    """Passes when index dimensions match expected."""
+    driver = _mock_driver_with_index(1536)
+    result = PreflightResult()
+    await _check_vector_index(driver, "neo4j", 1536, result)
+    assert result.vector_index_dimensions == 1536
+
+
+@pytest.mark.asyncio
+async def test_vector_index_mismatched_dimensions() -> None:
+    """Raises PreflightError when index dimensions don't match."""
+    driver = _mock_driver_with_index(768)
+    result = PreflightResult()
+    with pytest.raises(PreflightError, match="768 dimensions but embedder is configured for 1536"):
+        await _check_vector_index(driver, "neo4j", 1536, result)
+
+
+@pytest.mark.asyncio
+async def test_vector_index_none_when_missing() -> None:
+    """Returns None dimensions when no vector index exists."""
+    driver = _mock_driver_no_indexes()
+    result = PreflightResult()
+    await _check_vector_index(driver, "neo4j", 1536, result)
+    assert result.vector_index_dimensions is None
+
+
+# ---------------------------------------------------------------------------
+# Voyage API Check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voyage_api_valid_key() -> None:
+    """Passes when Voyage API returns correct dimensions."""
+    mock_embed_result = MagicMock()
+    mock_embed_result.embeddings = [[0.1] * 1536]
+
+    mock_client = MagicMock()
+    mock_client.embed.return_value = mock_embed_result
+
+    mock_voyageai = MagicMock()
+    mock_voyageai.Client.return_value = mock_client
+
+    with patch.dict("sys.modules", {"voyageai": mock_voyageai}):
+        result = PreflightResult()
+        await _check_voyage_api("pa-test-key", 1536, result)
+        assert result.voyage_api_valid is True
+
+        mock_client.embed.assert_called_once_with(
+            ["preflight check"],
+            model="voyage-4",
+            input_type="document",
+            output_dimension=1536,
+        )
+
+
+@pytest.mark.asyncio
+async def test_voyage_api_invalid_key() -> None:
+    """Raises PreflightError when Voyage API call fails."""
+    mock_client = MagicMock()
+    mock_client.embed.side_effect = Exception("Invalid API key")
+
+    mock_voyageai = MagicMock()
+    mock_voyageai.Client.return_value = mock_client
+
+    with patch.dict("sys.modules", {"voyageai": mock_voyageai}):
+        result = PreflightResult()
+        with pytest.raises(PreflightError, match="Voyage AI API check failed"):
+            await _check_voyage_api("pa-bad-key", 1536, result)
+
+
+# ---------------------------------------------------------------------------
+# Full Preflight Run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_preflight_checks_all_pass() -> None:
+    """Full preflight passes when all individual checks succeed."""
+    with (
+        patch(
+            "graphrag_kg_pipeline.preflight._check_neo4j_connectivity",
+            new_callable=AsyncMock,
+        ) as mock_neo4j,
+        patch(
+            "graphrag_kg_pipeline.preflight._check_apoc",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "graphrag_kg_pipeline.preflight._check_existing_data",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "graphrag_kg_pipeline.preflight._check_vector_index",
+            new_callable=AsyncMock,
+        ),
+    ):
+        mock_neo4j.side_effect = lambda _d, _db, r: setattr(r, "neo4j_connected", True)
+
+        driver = AsyncMock()
+        result = await run_preflight_checks(driver, "neo4j", 1536, "")
+        assert isinstance(result, PreflightResult)
+        assert result.using_voyage is False
+
+
+@pytest.mark.asyncio
+async def test_run_preflight_checks_with_voyage() -> None:
+    """Full preflight includes Voyage check when API key is provided."""
+    with (
+        patch(
+            "graphrag_kg_pipeline.preflight._check_neo4j_connectivity",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "graphrag_kg_pipeline.preflight._check_apoc",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "graphrag_kg_pipeline.preflight._check_existing_data",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "graphrag_kg_pipeline.preflight._check_vector_index",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "graphrag_kg_pipeline.preflight._check_voyage_api",
+            new_callable=AsyncMock,
+        ) as mock_voyage,
+    ):
+        driver = AsyncMock()
+        result = await run_preflight_checks(driver, "neo4j", 1536, "pa-test-key")
+        assert result.using_voyage is True
+        mock_voyage.assert_called_once_with("pa-test-key", 1536, result)
+
+
+@pytest.mark.asyncio
+async def test_preflight_error_is_importable() -> None:
+    """Verify PreflightError is accessible from the package root."""
+    from graphrag_kg_pipeline import PreflightError as PkgPreflightError
+
+    assert PkgPreflightError is PreflightError


### PR DESCRIPTION
## Summary

- Adds automated pre-flight checks that run before every pipeline ingestion
- Catches Neo4j connectivity, APOC availability, vector index dimension mismatches, and invalid API keys **before** starting a ~1.5hr run
- Updates `--dry-run` cost estimates to reflect Voyage AI and gleaning pass 2
- Fixes pre-existing test env var leak (`VOYAGE_API_KEY` from `.env` leaking into `mock_env_vars` fixture)

## Pre-flight checks

| Check | Type | Behavior on failure |
|-------|------|-------------------|
| Neo4j connectivity | Critical | `PreflightError` — abort |
| APOC availability | Critical | `PreflightError` — abort |
| Existing data | Warning | Log warning with node count |
| Vector index dimensions | Critical | `PreflightError` if mismatch |
| Voyage AI API key | Critical | `PreflightError` if invalid |

## Files changed

| File | Change |
|------|--------|
| `src/.../preflight.py` | New module — 6 pre-flight checks |
| `src/.../scraper.py` | Wire `_run_preflight()` before Stage 1 |
| `src/.../cli.py` | `PreflightError` handling + updated `--dry-run` estimates |
| `src/.../__init__.py` | Export `PreflightError` |
| `tests/test_preflight.py` | 14 new tests |
| `tests/conftest.py` | Fix env var leak in `mock_env_vars` fixture |

## Test plan

- [x] 205 tests passing (191 existing + 14 new)
- [x] Ruff lint: all checks passed
- [x] Ruff format: 57 files already formatted
- [ ] Manual: run `graphrag-kg scrape --dry-run` to verify updated estimates
- [ ] Manual: run full ingestion to verify pre-flight output

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)