### PR TITLE
fix: Voyage AI dimensions 1536 → 1024

### DIFF
--- a/src/graphrag_kg_pipeline/embeddings/voyage.py
+++ b/src/graphrag_kg_pipeline/embeddings/voyage.py
@@ -26,14 +26,14 @@ class VoyageAIEmbeddings(Embedder):
     Attributes:
         model: Voyage AI model name (default: voyage-4).
         input_type: Embedding input type ("document" for indexing, "query" for search).
-        dimensions: Output embedding dimensions (default: 1536 to match existing index).
+        dimensions: Output embedding dimensions (default: 1024).
     """
 
     def __init__(
         self,
         model: str = "voyage-4",
         input_type: str = "document",
-        dimensions: int = 1536,
+        dimensions: int = 1024,
         **kwargs: Any,
     ) -> None:
         """Initialize the Voyage AI embedder.
@@ -41,7 +41,7 @@ class VoyageAIEmbeddings(Embedder):
         Args:
             model: Model name (default: voyage-4).
             input_type: Either "document" (for indexing) or "query" (for search).
-            dimensions: Output vector dimensions (default: 1536).
+            dimensions: Output vector dimensions (default: 1024).
             **kwargs: Additional arguments passed to Voyage AI client.
         """
         super().__init__()

--- a/src/graphrag_kg_pipeline/extraction/pipeline.py
+++ b/src/graphrag_kg_pipeline/extraction/pipeline.py
@@ -61,7 +61,7 @@ class JamaKGPipelineConfig:
     openai_api_key: str = ""
     llm_model: str = "gpt-4o"
     embedding_model: str = "text-embedding-3-small"
-    embedding_dimensions: int = 1536
+    embedding_dimensions: int = 1024
 
     # Voyage AI configuration (optional — auto-detected from VOYAGE_API_KEY)
     voyage_api_key: str = ""


### PR DESCRIPTION
## Summary

- voyage-4 accepts 256, 512, 1024, or 2048 — **not** 1536
- Pre-flight validation caught this on the first re-ingestion attempt
- Changes default from 1536 to 1024 in `JamaKGPipelineConfig` and `VoyageAIEmbeddings`

## Test plan

- [x] 205 tests passing
- [x] Pre-flight check will validate on next ingestion run

🤖 Generated with [Claude Code](https://claude.com/claude-code)