### PR TITLE
Fix voyage-4 dimensions in .env.example comment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ OPENAI_API_KEY="sk-..."
 # =============================================================================
 # Voyage AI (optional — preferred for embeddings)
 # =============================================================================
-# When set, voyage-4 (1536d, asymmetric) is auto-detected for embeddings.
+# When set, voyage-4 (1024d, asymmetric) is auto-detected for embeddings.
 # When absent, falls back to OpenAI text-embedding-3-small.
 # VOYAGE_API_KEY=""
 


### PR DESCRIPTION
## Summary
- Corrects comment in `.env.example`: `1536d` → `1024d` to match actual voyage-4 default

One-line comment fix — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)