### PR TITLE
Fix chunk ordering property name in LangExtract query

### DIFF
--- a/src/graphrag_kg_pipeline/postprocessing/langextract_augmenter.py
+++ b/src/graphrag_kg_pipeline/postprocessing/langextract_augmenter.py
@@ -221,7 +221,7 @@ class LangExtractAugmenter:
             MATCH (c:Chunk)
             WHERE c.text IS NOT NULL AND size(c.text) > 50
             RETURN elementId(c) AS id, c.text AS text
-            ORDER BY c.chunk_index
+            ORDER BY c.index
             {limit_clause}
         """
         chunks = []


### PR DESCRIPTION
## Summary
- Fixes `ORDER BY c.chunk_index` → `ORDER BY c.index` in `langextract_augmenter.py`
- `chunk_index` doesn't exist; neo4j_graphrag creates the property as `index` (via `DEFAULT_CHUNK_INDEX_PROPERTY`)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)