### PR TITLE
feat: enrich null webinar thumbnails via OG image fallback

### DIFF
--- a/src/graphrag_kg_pipeline/parser.py
+++ b/src/graphrag_kg_pipeline/parser.py
@@ -377,6 +377,27 @@ class HTMLParser:
 
         return chapters
 
+    def extract_og_image(self, html: str) -> str | None:
+        """Extract the Open Graph image URL from an HTML page.
+
+        Parses ``<meta property="og:image" content="...">`` to recover a
+        thumbnail when the source article has no ``<img>`` inside the webinar
+        link.
+
+        Args:
+            html: Raw HTML of the page to parse.
+
+        Returns:
+            The ``og:image`` URL string, or ``None`` if not found or empty.
+        """
+        soup = BeautifulSoup(html, "lxml")
+        meta = soup.find("meta", property="og:image")
+        if meta and isinstance(meta, Tag):
+            content = meta.get("content", "")
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+        return None
+
     def _extract_title(self, soup: BeautifulSoup) -> str:
         """Extract the page title."""
         # Try h1 first


### PR DESCRIPTION
## Summary

- Add `HTMLParser.extract_og_image()` to parse `<meta property="og:image">` from HTML pages
- Add `JamaGuideScraper._enrich_webinar_thumbnails()` to fetch unique webinar landing pages and backfill null thumbnails
- Wire enrichment into `scrape_all()` after guide construction, reusing the existing fetcher context

Fixes 13 Webinar nodes that had `thumbnail_url = null` because they were plain-text links (not image links) in the source articles. The ~8 unique URLs add ~8 seconds to the scrape run.

## Test plan

- [x] `TestExtractOgImage` (5 tests): standard, missing, empty, whitespace, full-page HTML
- [x] `TestEnrichWebinarThumbnails` (4 async tests): happy path, URL deduplication, skip existing, fetch failure
- [x] All 224 existing tests still pass
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [ ] Smoke test: `uv run graphrag-kg scrape --scrape-only` to verify enrichment output (requires network)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)