### PR TITLE
feat: add local staging Neo4j instance + production safety prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,29 @@ NEO4J_URI="neo4j+s://xxx.databases.neo4j.io"
 NEO4J_USERNAME="neo4j"
 NEO4J_PASSWORD=""
 NEO4J_DATABASE="neo4j"
+
+# =============================================================================
+# Local Staging (Neo4j Desktop)
+# =============================================================================
+# The pipeline supports a local staging workflow using Neo4j Desktop.
+# Staging lets you validate pipeline output before committing to a production
+# rebuild (~1.5 hours, ~$9-17 in API costs).
+#
+# Setup:
+#   1. Open Neo4j Desktop → "New" → "Create local DBMS"
+#      Name: graphrag-api-db-stage, Password: stagingpassword, Version: latest 5.x
+#   2. Start the DBMS → Plugins tab → Install APOC
+#   3. Verify: Neo4j Browser → RETURN apoc.version()
+#
+# Switch terminal to staging:
+#   eval $(./scripts/neo4j-staging.sh env)
+#
+# VS Code: Use "Run: Pipeline CLI (Staging)" or "Validate: Staging" launch configs.
+#
+# Promotion workflow:
+#   1. Run pipeline against staging → validate → inspect in Neo4j Browser
+#   2. ./scripts/neo4j-staging.sh promote
+#      (dumps staging DB and uploads to production Aura)
+#
+# Production values above are NOT overridden when staging env vars are exported,
+# because load_dotenv() does not override existing shell environment variables.

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,9 @@ logs/
 .enrichment_cache/
 test_output/
 
+# Neo4j database dumps (staging promote)
+backups/
+
 # Local documentation (research notes, internal analysis)
 docs/*
 !docs/architecture.drawio

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,38 @@
       "args": []
     },
     {
+      "name": "Run: Pipeline CLI (Staging)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "graphrag_kg_pipeline.cli",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "NEO4J_URI": "bolt://localhost:7687",
+        "NEO4J_USERNAME": "neo4j",
+        "NEO4J_PASSWORD": "stagingpassword",
+        "NEO4J_DATABASE": "neo4j"
+      },
+      "args": ["scrape", "--full"]
+    },
+    {
+      "name": "Validate: Staging",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "graphrag_kg_pipeline.cli",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "NEO4J_URI": "bolt://localhost:7687",
+        "NEO4J_USERNAME": "neo4j",
+        "NEO4J_PASSWORD": "stagingpassword",
+        "NEO4J_DATABASE": "neo4j"
+      },
+      "args": ["validate"]
+    },
+    {
       "name": "Run: run.py",
       "type": "debugpy",
       "request": "launch",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ This project uses strict Python standards enforced by Ruff and ty:
 The `.vscode/` directory contains:
 - `settings.json` - Ruff integration, Pylance, pytest, format-on-save
 - `extensions.json` - Recommended extensions (Ruff, Pylance, etc.)
-- `launch.json` - Debug configurations for CLI, run.py, and pytest
+- `launch.json` - Debug configurations for CLI, run.py, pytest, and staging (configs with "(Staging)" suffix target local Neo4j Desktop)
 
 ## Architecture
 
@@ -300,6 +300,13 @@ The pipeline executes 5 stages to transform web content into a queryable knowled
 - **Community Detection** - Leiden algorithm via `leidenalg` (reference implementation). Only semantic relationship types projected (not structural). Communities get LLM-generated summaries.
 - **LangExtract Augmentation** - Post-processing entity augmentation with source grounding (text span provenance). Runs in Phase A (before cleanup) so new entities get normalized in Phase B.
 - **Supplementary Structure** - Chapter, Resource, and Glossary nodes add navigational context
+
+**Staging/Production Switching:**
+- **Environment-Driven Targeting** - `load_dotenv()` without `override=True` means shell-exported vars beat `.env` values. `eval $(./scripts/neo4j-staging.sh env)` exports staging vars; closing the terminal resets to production.
+- **Staging DBMS** - Neo4j Desktop, `bolt://localhost:7687`, password `stagingpassword`, APOC required
+- **Production Safety** - CLI shows green "(staging)" or yellow "(production)" labels; `--full` and `--fix` against production require interactive confirmation; `--dry-run` bypasses the prompt
+- **Promotion** - `./scripts/neo4j-staging.sh promote` dumps staging DB + uploads to Aura. Requires DBMS stopped for dump. Fallback: manual upload via Aura Console UI.
+- **VS Code Configs** - "(Staging)" suffix configs use inline `env` overrides (not `envFile`), so they always target localhost regardless of `.env` contents
 
 **Data Quality:**
 - **Validation Framework** - Comprehensive checks for orphans, duplicates, and invalid patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,12 @@ uv run ty check src/         # Type check
 uv run python examples/validate_toc_discovery.py
 ```
 
+## Conventions
+
+- Conventional commits: `fix:`, `feat:`, `refactor:`, `docs:`
+- Git workflow: Issue → Branch → PR
+- **CLAUDE.md & memory files — NO separate workflow**: Changes that ONLY touch `CLAUDE.md` or `~/.claude/` memory files MUST NOT get their own issue, branch, or PR. Bundle them into the next phase's PR, or commit directly to the working branch. See global CLAUDE.md for full rule.
+
 ## Code Style Standards
 
 This project uses strict Python standards enforced by Ruff and ty:

--- a/scripts/neo4j-staging.sh
+++ b/scripts/neo4j-staging.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# neo4j-staging.sh — Manage local Neo4j Desktop staging instance
+#
+# Subcommands:
+#   env      Print export statements for staging Neo4j env vars
+#   status   Test connectivity to local staging DBMS
+#   promote  Dump staging DB and upload to production Aura
+#
+# Usage:
+#   eval $(./scripts/neo4j-staging.sh env)    # Switch terminal to staging
+#   ./scripts/neo4j-staging.sh status         # Check staging connectivity
+#   ./scripts/neo4j-staging.sh promote        # Promote staging → production
+
+set -euo pipefail
+
+# Staging connection defaults
+STAGING_URI="bolt://localhost:7687"
+STAGING_USERNAME="neo4j"
+STAGING_PASSWORD="stagingpassword"
+STAGING_DATABASE="neo4j"
+
+BACKUP_DIR="./backups"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <command>
+
+Commands:
+  env       Print export statements for staging Neo4j env vars
+  status    Test connectivity to local staging DBMS and show node count
+  promote   Dump staging database and upload to production Aura
+
+Examples:
+  eval \$(./scripts/neo4j-staging.sh env)   # Switch shell to staging
+  ./scripts/neo4j-staging.sh status         # Check staging is reachable
+  ./scripts/neo4j-staging.sh promote        # Promote staging to production
+EOF
+    exit 1
+}
+
+# ─── env ──────────────────────────────────────────────────────────────────────
+
+cmd_env() {
+    cat <<EOF
+export NEO4J_URI="${STAGING_URI}"
+export NEO4J_USERNAME="${STAGING_USERNAME}"
+export NEO4J_PASSWORD="${STAGING_PASSWORD}"
+export NEO4J_DATABASE="${STAGING_DATABASE}"
+EOF
+}
+
+# ─── status ───────────────────────────────────────────────────────────────────
+
+cmd_status() {
+    echo "Checking staging DBMS at ${STAGING_URI}..."
+    echo
+
+    # Try cypher-shell first (comes with Neo4j Desktop)
+    if command -v cypher-shell &>/dev/null; then
+        if cypher-shell -u "${STAGING_USERNAME}" -p "${STAGING_PASSWORD}" \
+            -a "${STAGING_URI}" -d "${STAGING_DATABASE}" \
+            "RETURN 'connected' AS status" &>/dev/null; then
+            echo "  Connected to staging DBMS"
+            echo
+            node_count=$(cypher-shell -u "${STAGING_USERNAME}" -p "${STAGING_PASSWORD}" \
+                -a "${STAGING_URI}" -d "${STAGING_DATABASE}" \
+                --format plain \
+                "MATCH (n) RETURN count(n) AS nodes" 2>/dev/null | tail -1)
+            echo "  Node count: ${node_count}"
+        else
+            echo "  ERROR: Cannot connect to staging DBMS at ${STAGING_URI}"
+            echo "  Make sure the DBMS is started in Neo4j Desktop."
+            exit 1
+        fi
+    else
+        echo "  cypher-shell not found in PATH."
+        echo
+        echo "  Options:"
+        echo "    1. Open Neo4j Desktop → DBMS '...' menu → Terminal"
+        echo "       Then run: cypher-shell -u neo4j -p stagingpassword"
+        echo "    2. Open Neo4j Browser (via Desktop) and run:"
+        echo "       MATCH (n) RETURN count(n)"
+        exit 1
+    fi
+}
+
+# ─── promote ──────────────────────────────────────────────────────────────────
+
+cmd_promote() {
+    # Read production URI from .env file
+    if [[ ! -f .env ]]; then
+        echo "ERROR: .env file not found. Cannot determine production URI."
+        exit 1
+    fi
+
+    prod_uri=$(grep -E '^NEO4J_URI=' .env | sed 's/^NEO4J_URI=//' | tr -d '"' | tr -d "'")
+    if [[ -z "${prod_uri}" ]]; then
+        echo "ERROR: NEO4J_URI not found in .env file."
+        exit 1
+    fi
+
+    echo "=== Staging → Production Promotion ==="
+    echo
+    echo "  Staging:    ${STAGING_URI}"
+    echo "  Production: ${prod_uri}"
+    echo
+    echo "  WARNING: This will OVERWRITE the production database."
+    echo
+    read -rp "  Continue? [y/N]: " confirm
+    if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
+        echo "  Aborted."
+        exit 0
+    fi
+
+    echo
+
+    # Create backup directory
+    mkdir -p "${BACKUP_DIR}"
+    timestamp=$(date +%Y%m%dT%H%M%S)
+    dump_file="${BACKUP_DIR}/staging-${timestamp}.dump"
+
+    # Check if neo4j-admin is available
+    if ! command -v neo4j-admin &>/dev/null; then
+        echo "  neo4j-admin not found in PATH."
+        echo
+        echo "  Manual promotion steps:"
+        echo
+        echo "  1. STOP the staging DBMS in Neo4j Desktop"
+        echo
+        echo "  2. Open Desktop Terminal (DBMS '...' menu → Terminal) and run:"
+        echo "     neo4j-admin database dump neo4j --to-path=${BACKUP_DIR}"
+        echo
+        echo "  3. Upload to Aura Console:"
+        echo "     - Go to https://console.neo4j.io"
+        echo "     - Select your instance → 'Restore from backup file'"
+        echo "     - Upload the .dump file from ${BACKUP_DIR}/"
+        echo
+        echo "  OR use neo4j-admin database upload (from Desktop Terminal):"
+        echo "     neo4j-admin database upload neo4j \\"
+        echo "       --to-uri=${prod_uri} \\"
+        echo "       --overwrite-destination=true"
+        exit 0
+    fi
+
+    # Verify staging DBMS is stopped (required for dump)
+    if cypher-shell -u "${STAGING_USERNAME}" -p "${STAGING_PASSWORD}" \
+        -a "${STAGING_URI}" "RETURN 1" &>/dev/null 2>&1; then
+        echo "  ERROR: Staging DBMS is still running."
+        echo "  Please STOP it in Neo4j Desktop before dumping."
+        echo "  (Desktop → graphrag-api-db-stage → click 'Stop')"
+        exit 1
+    fi
+
+    echo "  Dumping staging database to ${dump_file}..."
+    neo4j-admin database dump "${STAGING_DATABASE}" --to-path="${BACKUP_DIR}"
+
+    # Rename the dump to include timestamp
+    if [[ -f "${BACKUP_DIR}/${STAGING_DATABASE}.dump" ]]; then
+        mv "${BACKUP_DIR}/${STAGING_DATABASE}.dump" "${dump_file}"
+    fi
+
+    echo "  Dump complete: ${dump_file}"
+    echo
+
+    echo "  Uploading to production (${prod_uri})..."
+    neo4j-admin database upload "${STAGING_DATABASE}" \
+        --to-uri="${prod_uri}" \
+        --overwrite-destination=true
+
+    echo
+    echo "  Promotion complete!"
+    echo
+    echo "  Next steps:"
+    echo "    1. Restart staging DBMS in Neo4j Desktop"
+    echo "    2. Open a new terminal (fresh env → production)"
+    echo "    3. Run: graphrag-kg validate"
+}
+
+# ─── main ─────────────────────────────────────────────────────────────────────
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+case "$1" in
+    env)     cmd_env ;;
+    status)  cmd_status ;;
+    promote) cmd_promote ;;
+    *)       usage ;;
+esac


### PR DESCRIPTION
## Summary

- Add local staging workflow using Neo4j Desktop to validate pipeline output before committing to production rebuilds (~1.5h, ~$9-17 in API costs)
- Add `scripts/neo4j-staging.sh` with `env`, `status`, and `promote` subcommands
- Add production safety prompts to CLI: target URI display (green staging / yellow production) and confirmation prompt for destructive operations (`--full`, `--fix`) against production
- Add VS Code staging launch configs with inline `env` overrides
- Document Neo4j Desktop setup, `eval $()` pattern, and promotion workflow

## Test plan

- [x] 256 tests pass, ruff clean, ty clean
- [x] Full staging pipeline run completed successfully (108/108 articles)
- [x] `eval $(./scripts/neo4j-staging.sh env)` exports correct staging vars
- [x] Staging graph validated in Neo4j Browser
- [ ] `graphrag-kg validate --dry-run` in fresh terminal shows yellow production label
- [ ] `--full` against production URI triggers confirmation prompt

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)